### PR TITLE
add get_url method to accessor

### DIFF
--- a/ftrack_s3_accessor/s3.py
+++ b/ftrack_s3_accessor/s3.py
@@ -287,3 +287,13 @@ class S3Accessor(Accessor):
 
         s3_object = self.bucket.Object(resource_identifier)
         s3_object.put(Body='')
+
+    def get_url(self, resource_identifier=None):
+        '''Return url for *resource_identifier*.'''
+        s3_object = self.bucket.Object(resource_identifier)
+        try:
+            location = boto3.client('s3').get_bucket_location(Bucket=self.bucket_name)['LocationConstraint']
+            url = "https://s3-{}.amazonaws.com/{}/{}".format(location, self.bucket_name, s3_object.key)
+        except Exception:
+            url = 'Missing, GetBucketLocation option.... please enable on the bucket to render component path.'
+        return url

--- a/ftrack_s3_accessor/s3.py
+++ b/ftrack_s3_accessor/s3.py
@@ -12,14 +12,14 @@ except ImportError:
     pass
 
 from ftrack_api.accessor.base import Accessor
-from ftrack_api.exception import AccessorFilesystemPathError
 from ftrack_api.data import FileWrapper
 from ftrack_api.exception import (AccessorOperationFailedError,
                                   AccessorUnsupportedOperationError,
                                   AccessorResourceInvalidError,
                                   AccessorResourceNotFoundError,
                                   AccessorContainerNotEmptyError,
-                                  AccessorParentResourceNotFoundError)
+                                  AccessorParentResourceNotFoundError,
+                                  AccessorFilesystemPathError)
 
 
 class S3File(FileWrapper):


### PR DESCRIPTION
Provide missing get_url to accessor.
This is required for the accessor to render component path in studio application.

There an exeption set in case the permission on s3 are not availables.